### PR TITLE
updating ruby version in gem files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # A sample Gemfile
 source "https://rubygems.org"
-ruby '~> 2.4.2'
+ruby '~> 2.6.6'
 
 gem "oauth2"
 gem "slack-notifier"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ DEPENDENCIES
   slack-notifier
 
 RUBY VERSION
-   ruby 2.4.2p198
+   ruby 2.6.6
 
 BUNDLED WITH
    2.0.2


### PR DESCRIPTION
## Changes proposed in this pull request:
-bumped ruby version from 2.4.2 -> 2.6.6 because of the buildpack removed 2.4.x

## security considerations
None
