### PR TITLE
Update rack >= 2.1.4 by updating oauth2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # A sample Gemfile
 source "https://rubygems.org"
-ruby '~> 2.6.6'
+ruby "~> 2.7.0"
 
-gem "oauth2"
+gem "oauth2", "~> 1.4.0"
 gem "slack-notifier"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,30 +1,30 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    faraday (0.9.2)
+    faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
-    jwt (1.5.1)
-    multi_json (1.11.2)
-    multi_xml (0.5.5)
-    multipart-post (2.0.0)
-    oauth2 (1.0.0)
-      faraday (>= 0.8, < 0.10)
-      jwt (~> 1.0)
+    jwt (2.2.2)
+    multi_json (1.15.0)
+    multi_xml (0.6.0)
+    multipart-post (2.1.1)
+    oauth2 (1.4.4)
+      faraday (>= 0.8, < 2.0)
+      jwt (>= 1.0, < 3.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
-      rack (~> 1.2)
-    rack (1.6.12)
+      rack (>= 1.2, < 3)
+    rack (2.2.3)
     slack-notifier (1.4.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  oauth2
+  oauth2 (~> 1.4.0)
   slack-notifier
 
 RUBY VERSION
-   ruby 2.6.6
+   ruby 2.7.0p0
 
 BUNDLED WITH
-   2.0.2
+   2.1.4


### PR DESCRIPTION
Came across this alert while looking into the Tock sandbox creation issue.  Not a ruby person but tests pass 🤷. Maybe worth pairing next week to make sure nothing breaks with the oauth2 minor upgrade.

## Changes proposed in this pull request:
- Update oauth2 to ~>1.4.0 
- Updates rack

## security considerations
- Fixes dependabot alert for rack >= 2.1.4
