### PR TITLE
updating ruby from 2.7 to 3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # A sample Gemfile
 source "https://rubygems.org"
-ruby "~> 2.7.0"
+ruby "~> 3.1.0"
 
 gem "oauth2", "~> 1.4.0"
 gem "slack-notifier"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ DEPENDENCIES
   slack-notifier
 
 RUBY VERSION
-   ruby 2.7.0p0
+   ruby 3.1.0
 
 BUNDLED WITH
-   2.1.4
+   2.4.10


### PR DESCRIPTION
## Changes proposed in this pull request:
- updating version of ruby
-
-

## security considerations
Increase security as support for 2.7 of ruby is dieing
