### PR TITLE
External csv changed column name to lower case

### DIFF
--- a/monitor_helper.rb
+++ b/monitor_helper.rb
@@ -4,7 +4,7 @@ module MonitorHelper
 
   if ENV['DOMAIN_CSV_PATH']
     @@domains = CSV.read(ENV['DOMAIN_CSV_PATH'], headers: true).map do |row|
-      row['Domain Name'].downcase
+      row['Domain name'].downcase
     end
 
     # The GSA domain list this is likely pulling in, doesn't include .mil domains


### PR DESCRIPTION
## Changes proposed in this pull request:
- sandbox-bot app started to crash with the error seen below.  It takes as input a CSV file from a `dotgov-data` repo.
- Our code looks for a column called `Domain Name` but they renamed it `Domain name` so the ruby code was pulling back a nil value.
- Changing to the new column naming format

Error it fixes:

```
   2024-01-31T08:31:39.98-0500 [APP/PROC/WEB/0] ERR /home/vcap/app/monitor_helper.rb:7:in `block in <module:MonitorHelper>': undefined method `downcase' for nil:NilClass (NoMethodError)
   2024-01-31T08:31:39.98-0500 [APP/PROC/WEB/0] ERR row['Domain Name'].downcase
   2024-01-31T08:31:39.98-0500 [APP/PROC/WEB/0] ERR ^^^^^^^^^
```

The format change happened upstream with this commit: https://github.com/cisagov/dotgov-data/commit/e0bd9a9d6b651deacb895cbdf3fecd70f1332cc6


## security considerations
None
