### PR TITLE
setup integrate task to use hardened image

### DIFF
--- a/integrate.yml
+++ b/integrate.yml
@@ -2,9 +2,13 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: alpine
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: general-task
+    aws_region: us-gov-west-1
+    tag: latest
 
 inputs:
 - name: git-sandbox-bot


### PR DESCRIPTION
## Changes proposed in this pull request:
- Update the integrate task file to use the hardened general-task image rather than the alpine image from dockerhub

## security considerations
Update task to use hardened image
